### PR TITLE
Fix stdlib symbols not recognized by default

### DIFF
--- a/bazel/aspect/BUILD.bazel
+++ b/bazel/aspect/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//:stdlib.bzl", "stdlib_to_bin")
+
 proto_library(
     name = "kotlin_lsp_proto",
     srcs = ["kotlin_lsp.proto"],
@@ -13,5 +15,10 @@ java_proto_library(
 alias(
     name = "lsp_info_extractor",
     actual = "//lsp_info_extractor:lsp_info_extractor",
+    visibility = ["//visibility:public"],
+)
+
+stdlib_to_bin(
+    name = "stdlib-jars",
     visibility = ["//visibility:public"],
 )

--- a/bazel/aspect/WORKSPACE
+++ b/bazel/aspect/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "kotlin_lsp_aspect")
+workspace(name = "bazel_kotlin_lsp")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/bazel/aspect/providers.bzl
+++ b/bazel/aspect/providers.bzl
@@ -1,0 +1,14 @@
+KotlinLSPStdLibInfo = provider(
+    doc = "Information about the kotlin stdlib extracted from the kotlin toolchain",
+    fields = {
+        "compile_jar": "The kotlin-stdlib compile jar",
+    },
+)
+
+KotlinLspInfo = provider(
+    doc = "Contains the information leveraged by Kotlin Language Server for a target.",
+    fields = {
+        "info": "Provides info regarding classpath entries for direct deps.",
+        "transitive_infos": "Provides info regarding classpath entries for transitive deps.",
+    },
+)

--- a/bazel/aspect/stdlib.bzl
+++ b/bazel/aspect/stdlib.bzl
@@ -1,0 +1,33 @@
+load(":providers.bzl", "KotlinLSPStdLibInfo")
+
+def _stdlib_to_bin_impl(ctx):
+    jvm_stdlibs = ctx.toolchains["@io_bazel_rules_kotlin//kotlin/internal:kt_toolchain_type"].jvm_stdlibs
+
+    outputs = []
+    output_compile_jar = None
+    for java_output in jvm_stdlibs.java_outputs:
+        class_jar = java_output.class_jar
+        if class_jar.path.endswith("-stdlib.jar"):
+            output_compile_jar = ctx.actions.declare_file("kotlin-stdlib.jar")
+            ctx.actions.symlink(
+                output = output_compile_jar,
+                target_file = class_jar,
+            )
+            outputs.append(output_compile_jar)
+
+    return [
+        DefaultInfo(
+            files = depset(outputs),
+        ),
+        KotlinLSPStdLibInfo(
+            compile_jar = output_compile_jar,
+        ),
+    ]
+
+stdlib_to_bin = rule(
+    implementation = _stdlib_to_bin_impl,
+    doc = "Copies the kotlin stdlib jars to the output tree to make it available to the aspect to include it in the classpath",
+    toolchains = [
+        "@io_bazel_rules_kotlin//kotlin/internal:kt_toolchain_type",
+    ],
+)

--- a/src/bazelUtils.ts
+++ b/src/bazelUtils.ts
@@ -25,34 +25,14 @@ async function checkDirectoryExists(path: string) {
 }
 
 export async function getBazelAspectArgs(
-  extensionSourcesPath: string,
-  isDevelopmentMode: boolean
+  aspectSourcesPath: string,
 ): Promise<string[]> {
-  const files = await fs.readdir(extensionSourcesPath);
-  let extensionRepoRoot: string | undefined = extensionSourcesPath;
-  // If we are in development mode, the extension sources are in the repository where the extension is checked out
-  // so use the aspect from there
-  if (!isDevelopmentMode) {
-    extensionRepoRoot = files.find(async (file) => {
-      (await isDirectory(file)) &&
-        file.includes("bazel-kotlin-vscode-extension");
-    });
-  }
-  if (!extensionRepoRoot) {
-    throw new Error(
-      `Extension sources root not found in ${extensionSourcesPath}`
-    );
-  }
 
   let aspectWorkspacePath = path.join(
-    extensionSourcesPath,
-    extensionRepoRoot,
+    aspectSourcesPath,
     "bazel",
     "aspect"
   );
-  if (!isDevelopmentMode) {
-    aspectWorkspacePath = path.join(extensionSourcesPath, "bazel", "aspect");
-  }
   if (!checkDirectoryExists(aspectWorkspacePath)) {
     throw new Error(
       `Bazel Aspect workspace not found at ${aspectWorkspacePath}`

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ export interface BazelKLSConfig {
     languageServerLocalPath: string | null;
     debugAttachEnabled: boolean;
     debugAttachPort: number;
-    extensionSourcesPath: string;
+    aspectSourcesPath: string;
     buildFlags: string[];
 }
 
@@ -19,11 +19,11 @@ export class ConfigurationManager {
     private static readonly SECTION = 'bazelKLS';
     private languageServerInstallPath: string;
     private config: vscode.WorkspaceConfiguration;
-    private extensionSourcesPath: string;
+    private aspectSourcesPath: string;
 
     constructor(storagePath: string) {
         this.languageServerInstallPath = path.join(storagePath, 'languageServer');
-        this.extensionSourcesPath = path.join(storagePath, 'extensionSources');
+        this.aspectSourcesPath = path.join(storagePath, 'aspectSources');
         this.config = vscode.workspace.getConfiguration(ConfigurationManager.SECTION);
     }
 
@@ -38,7 +38,7 @@ export class ConfigurationManager {
                 languageServerLocalPath: this.config.get('path', null),
                 debugAttachEnabled: this.config.get('debugAttach.enabled', false),
                 debugAttachPort: this.config.get('debugAttach.port', 5009),
-                extensionSourcesPath: this.extensionSourcesPath,
+                aspectSourcesPath: this.aspectSourcesPath,
                 buildFlags: this.config.get("buildFlags", []),
         };
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -177,15 +177,14 @@ export async function activate(context: vscode.ExtensionContext) {
         }
 
         // Then build those targets with the aspect
-        let extensionSourcesPath = config.extensionSourcesPath;
+        let aspectSourcesPath = config.aspectSourcesPath;
 
         if (context.extensionMode === vscode.ExtensionMode.Development) {
-          extensionSourcesPath = context.extensionUri.fsPath;
+          aspectSourcesPath = context.extensionUri.fsPath;
         }
 
         const bazelAspectArgs = await getBazelAspectArgs(
-          extensionSourcesPath,
-          context.extensionMode === vscode.ExtensionMode.Development
+          aspectSourcesPath,
         );
         const buildCmd = `bazel build ${config.buildFlags.join(" ")} ${targets.join(
           " "
@@ -299,7 +298,7 @@ async function downloadAspectRelease(
   config: BazelKLSConfig,
   context: vscode.ExtensionContext
 ) {
-  const sourcesPath = config.extensionSourcesPath;
+  const sourcesPath = config.aspectSourcesPath;
   const sourcesVersionFile = path.join(sourcesPath, "version");
 
   if (fs.existsSync(sourcesVersionFile)) {

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -44,7 +44,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
             path.join(testContext.storagePath, 'languageServer')
         );
         assert.strictEqual(
-            config.extensionSourcesPath, 
+            config.aspectSourcesPath, 
             path.join(testContext.storagePath, 'extensionSources')
         );
     });

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -45,7 +45,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
         );
         assert.strictEqual(
             config.aspectSourcesPath, 
-            path.join(testContext.storagePath, 'extensionSources')
+            path.join(testContext.storagePath, 'aspectSources')
         );
     });
 


### PR DESCRIPTION
Solves #11 

Update the aspect to also pull in the stdlib. this was a bit tricky, I had to create another rule that produces the stdlib as an output so that the aspect can include it in the classpath and the output group. After this, stlib symbols are recognized.

Also fix confusion around how aspect sources are loaded in development vs production