### PR TITLE
Add initial debugger config

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
             "properties": {
               "bazelTarget": {
                 "type": "string",
-                "description": "the bazel binary/test target to debug",
+                "description": "the bazel binary/test target to debug"
               },
               "mainClass": {
                 "type": "string",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,13 @@
     "vscode": "^1.94.0"
   },
   "categories": [
-    "Other"
+    "Other",
+    "Programming Languages",
+    "Debuggers"
   ],
   "activationEvents": [
-    "onLanguage:kotlin"
+    "onLanguage:kotlin",
+    "onDebug"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -31,6 +34,11 @@
           "kotlin"
         ],
         "configuration": "./languageConfiguration.json"
+      }
+    ],
+    "breakpoints": [
+      {
+        "language": "kotlin"
       }
     ],
     "grammars": [
@@ -49,6 +57,32 @@
         "command": "bazel-kotlin-vscode-extension.clearCaches",
         "title": "Kotlin: Clear Language Server Caches",
         "category": "Kotlin"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "kotlin",
+        "label": "Debug Bazel Kotlin/JVM binary",
+        "configurationAttributes": {
+          "launch": {
+            "required": ["bazelTarget", "mainClass", "workspaceRoot"],
+            "properties": {
+              "bazelTarget": {
+                "type": "string",
+                "description": "the bazel binary/test target to debug",
+              },
+              "mainClass": {
+                "type": "string",
+                "description": "the main class for the binary/test target"
+              },
+              "workspaceRoot": {
+                "type": "string",
+                "description": "the bazel workspace root",
+                "default": "${workspaceFolder}"
+              }
+            }
+          }
+        }
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "label": "Debug Bazel Kotlin/JVM binary",
         "configurationAttributes": {
           "launch": {
-            "required": ["bazelTarget", "mainClass", "workspaceRoot"],
+            "required": ["bazelTarget", "mainClass", "workspaceRoot", "buildFlags"],
             "properties": {
               "bazelTarget": {
                 "type": "string",
@@ -79,6 +79,10 @@
                 "type": "string",
                 "description": "the bazel workspace root",
                 "default": "${workspaceFolder}"
+              },
+              "buildFlags": {
+                "type": "array",
+                "description": "a list of bazel flags to used in the bazel build by the debug adapter before launching the program"
               }
             }
           }


### PR DESCRIPTION
Towards #9 

Adds initial debugging configuration in the extension for a launch configuration:
- a bazel target (so we can do a build first if we haven't synced already)
- build flags so that we can pass the aspect flags to the debug adapter to be used in the build
- the main class to launch which is required for the JDI interface
- workspace root, this is required in place of projectRoot. This makes sense for the gradle/maven setup to discover source files, in bazel land we'll need to discover the source files in the transitive closure of the target