### PR TITLE
Generate JVM class names for source files

### DIFF
--- a/bazel/aspect/kotlin_lsp.proto
+++ b/bazel/aspect/kotlin_lsp.proto
@@ -11,7 +11,6 @@ message KotlinLspBazelTargetInfo {
     // The bazel target label
     string bazel_target = 2;
 
-
     // One or more classpath entries, this only includes the direct compile/source jar for the target
     // and not all its transitive dependencies. this is to avoid bloating this proto file
     repeated ClassPathEntry classpath = 3;
@@ -34,6 +33,11 @@ message PackageSourceMapping {
 message SourceFile {
     // relative path to the source file contained in a target
     string path = 1;
+
+    // one or more JVM names for the classes in this file
+    // this is to allow the debugger to set the breakpoints using JDI which
+    // requires class filters with JVM names
+    repeated string jvm_class_names = 2;
 }
 
 message ClassPathEntry {

--- a/bazel/aspect/lsp_info_extractor/src/kotlin/org/bazelkls/JvmNameExtractor.kt
+++ b/bazel/aspect/lsp_info_extractor/src/kotlin/org/bazelkls/JvmNameExtractor.kt
@@ -1,0 +1,69 @@
+package org.bazelkls
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.Opcodes
+import java.io.File
+import java.util.jar.JarFile
+
+class JvmNameExtractor {
+    data class SourceFileJvmMapping(
+        val sourceFile: String,
+        val jvmClassNames: Set<String>
+    )
+
+    companion object {
+        fun extractMappings(classJars: List<String>): List<SourceFileJvmMapping> {
+            val sourceToJvmMap = mutableMapOf<String, MutableSet<String>>()
+
+            classJars.filter { it.isNotBlank() }.forEach { jarPath ->
+                val jarFile = File(jarPath)
+                if (jarFile.exists()) {
+                    try {
+                        scanJar(jarFile, sourceToJvmMap)
+                    } catch (e: Exception) {
+                        println("Error scanning jar $jarPath: ${e.message}")
+                    }
+                }
+            }
+
+            return sourceToJvmMap.map { (sourceFile, jvmNames) ->
+                SourceFileJvmMapping(sourceFile, jvmNames)
+            }
+        }
+
+        private fun scanJar(jarFile: File, sourceToJvmMap: MutableMap<String, MutableSet<String>>) {
+            JarFile(jarFile).use { jar ->
+                jar.entries().asSequence()
+                    .filter { it.name.endsWith(".class") }
+                    .forEach { entry ->
+                        try {
+                            jar.getInputStream(entry).use { input ->
+                                val classBytes = input.readBytes()
+                                processClass(classBytes, sourceToJvmMap)
+                            }
+                        } catch (e: Exception) {
+                            println("Error processing class ${entry.name}: ${e.message}")
+                        }
+                    }
+            }
+        }
+
+        private fun processClass(classBytes: ByteArray, sourceToJvmMap: MutableMap<String, MutableSet<String>>) {
+            val classReader = ClassReader(classBytes)
+            val jvmClassName = classReader.className.replace('/', '.')
+            println(jvmClassName)
+
+            classReader.accept(object : ClassVisitor(Opcodes.ASM9) {
+                override fun visitSource(source: String?, debug: String?) {
+                    println(source)
+                    if (source != null) {
+                        // Add this class to the source file mapping
+                        sourceToJvmMap.computeIfAbsent(source) { mutableSetOf() }.add(jvmClassName)
+                    }
+                    super.visitSource(source, debug)
+                }
+            }, ClassReader.SKIP_FRAMES)
+        }
+    }
+}

--- a/bazel/aspect/lsp_info_extractor/src/kotlin/org/bazelkls/JvmNameExtractor.kt
+++ b/bazel/aspect/lsp_info_extractor/src/kotlin/org/bazelkls/JvmNameExtractor.kt
@@ -52,11 +52,9 @@ class JvmNameExtractor {
         private fun processClass(classBytes: ByteArray, sourceToJvmMap: MutableMap<String, MutableSet<String>>) {
             val classReader = ClassReader(classBytes)
             val jvmClassName = classReader.className.replace('/', '.')
-            println(jvmClassName)
 
             classReader.accept(object : ClassVisitor(Opcodes.ASM9) {
                 override fun visitSource(source: String?, debug: String?) {
-                    println(source)
                     if (source != null) {
                         // Add this class to the source file mapping
                         sourceToJvmMap.computeIfAbsent(source) { mutableSetOf() }.add(jvmClassName)

--- a/bazel/aspect/lsp_info_extractor/src/kotlin/org/bazelkls/LspInfoExtractor.kt
+++ b/bazel/aspect/lsp_info_extractor/src/kotlin/org/bazelkls/LspInfoExtractor.kt
@@ -52,9 +52,24 @@ class ExtractLspInfo : CliktCommand() {
                 .build()
         }
 
-        val sourceFilesProtos = sourceFiles?.map {
+        val jvmNameMappings = JvmNameExtractor.extractMappings(classJars)
+        println(jvmNameMappings)
+        val filenameToJvmNames = jvmNameMappings.associate {
+            it.sourceFile to it.jvmClassNames
+        }
+
+        // When creating source file protos, include the JVM class names
+        val sourceFilesProtos = sourceFiles?.map { fullSourcePath ->
+            // Extract just the filename
+            val filename = fullSourcePath.substringAfterLast('/')
+
+            // Look up JVM names for this source file
+            println(filenameToJvmNames)
+            val jvmNames = filenameToJvmNames[filename] ?: emptySet()
+
             SourceFile.newBuilder()
-                .setPath(it)
+                .setPath(fullSourcePath)
+                .addAllJvmClassNames(jvmNames)
                 .build()
         }
 

--- a/bazel/aspect/lsp_info_extractor/src/kotlin/org/bazelkls/LspInfoExtractor.kt
+++ b/bazel/aspect/lsp_info_extractor/src/kotlin/org/bazelkls/LspInfoExtractor.kt
@@ -53,7 +53,6 @@ class ExtractLspInfo : CliktCommand() {
         }
 
         val jvmNameMappings = JvmNameExtractor.extractMappings(classJars)
-        println(jvmNameMappings)
         val filenameToJvmNames = jvmNameMappings.associate {
             it.sourceFile to it.jvmClassNames
         }
@@ -64,7 +63,6 @@ class ExtractLspInfo : CliktCommand() {
             val filename = fullSourcePath.substringAfterLast('/')
 
             // Look up JVM names for this source file
-            println(filenameToJvmNames)
             val jvmNames = filenameToJvmNames[filename] ?: emptySet()
 
             SourceFile.newBuilder()


### PR DESCRIPTION
Towards #9 

To be able to debug with the JDI interface, we need to infer the JVM class names for each source file so that the breakpoints can be set based on the class filter. The logic in the adapter right now https://github.com/smocherla-brex/kotlin-language-server-bazel-support/blob/main/adapter/src/main/kotlin/org/javacs/ktda/classpath/PathUtils.kt#L20 is really maven/gradle specific. Ideally we use the Kotlin compiller and then get it from the PSI but that's expensive, instead we can analyze the class jars during a build and generate this info from the aspect and consume it in the adapter.

As an example,

```
smocherla@NLC2L54QQY credit_card % cat bazel-bin/src/lib-kotlin-lsp.json
{
  "bazelTarget": "@//src:lib",
  "classpath": [{
    "compileJar": "bazel-out/darwin_arm64-fastbuild/bin/src/lib.jar",
    "sourceJar": "bazel-out/darwin_arm64-fastbuild/bin/src/lib-sources.jar"
  }, {
    "compileJar": "bazel-out/darwin_arm64-opt-exec/bin/external/bazel_kotlin_lsp/kotlin-stdlib.jar",
    "sourceJar": ""
  }],
  "sourceFiles": [{
    "path": "src/Extensions.kt",
    "jvmClassNames": ["bazel.lsp_fixtures.extensions.ExtensionsKt"]
  }, {
    "path": "src/Foo.kt",
    "jvmClassNames": ["bazel.lsp_fixtures.App$Companion", "bazel.lsp_fixtures.App"]
  }],
  "packageSourceMappings": [{
    "packageName": "bazel.lsp_fixtures",
    "sourceJarPath": "bazel-out/darwin_arm64-fastbuild/bin/src/lib-sources.jar"
  }, {
    "packageName": "bazel.lsp_fixtures.extensions",
    "sourceJarPath": "bazel-out/darwin_arm64-fastbuild/bin/src/lib-sources.jar"
  }]
}%    
```