### PR TITLE
Add debug adapter support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "Debuggers"
   ],
   "activationEvents": [
-    "onLanguage:kotlin",
-    "onDebug",
-    "onDebugResolve:kotlin"
+    "onDebug"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -63,12 +61,21 @@
     "debuggers": [
       {
         "type": "kotlin",
+        "label": "Debug Bazel Kotlin/JVM binary",
         "configurationSnippets": [
           {
-            "workspaceRoot": "${workspaceFolder}"
+            "label": "Debug Kotlin with Bazel",
+            "description": "Launch a Kotlin binary using Bazel",
+            "body": {
+              "type": "kotlin",
+              "name": "Launch Kotlin with Bazel",
+              "request": "launch",
+              "bazelTarget": "//my/package:my_binary",
+              "mainClass": "com.example.MainKt",
+              "workspaceRoot": "${workspaceFolder}"
+            }
           }
         ],
-        "label": "Debug Bazel Kotlin/JVM binary",
         "configurationAttributes": {
           "launch": {
             "required": ["bazelTarget", "mainClass", "workspaceRoot"],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   ],
   "activationEvents": [
     "onLanguage:kotlin",
-    "onDebug"
+    "onDebug",
+    "onDebugResolve:kotlin"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -62,10 +63,15 @@
     "debuggers": [
       {
         "type": "kotlin",
+        "configurationSnippets": [
+          {
+            "workspaceRoot": "${workspaceFolder}"
+          }
+        ],
         "label": "Debug Bazel Kotlin/JVM binary",
         "configurationAttributes": {
           "launch": {
-            "required": ["bazelTarget", "mainClass", "workspaceRoot", "buildFlags"],
+            "required": ["bazelTarget", "mainClass", "workspaceRoot"],
             "properties": {
               "bazelTarget": {
                 "type": "string",
@@ -83,6 +89,10 @@
               "buildFlags": {
                 "type": "array",
                 "description": "a list of bazel flags to used in the bazel build by the debug adapter before launching the program"
+              },
+              "additionalArgs": {
+                "type": "array",
+                "description": "an optional list of additional args to be passed to the main class"
               }
             }
           }
@@ -224,6 +234,11 @@
           "type": "boolean",
           "default": true,
           "description": "[Recommended] Specifies whether the debug adapter should be used. When enabled a debugger for Kotlin will be available."
+        },
+        "bazelKLS.debugAdapter.version": {
+          "type": "string",
+          "default": "v1.3.15-bazel",
+          "description": "The debug adapter version from Github releases"
         },
         "bazelKLS.debugAdapter.path": {
           "type": "string",

--- a/src/bazelUtils.ts
+++ b/src/bazelUtils.ts
@@ -1,24 +1,30 @@
-import { checkDirectoryExists } from "./dirUtils";{}
+import { checkDirectoryExists } from "./dirUtils";
+{
+}
 import * as path from "path";
 
 export async function getBazelAspectArgs(
   aspectSourcesPath: string,
+  quotePath: boolean = true
 ): Promise<string[]> {
-
-  let aspectWorkspacePath = path.join(
-    aspectSourcesPath,
-    "bazel",
-    "aspect"
-  );
+  let aspectWorkspacePath = path.join(aspectSourcesPath, "bazel", "aspect");
   if (!checkDirectoryExists(aspectWorkspacePath)) {
     throw new Error(
       `Bazel Aspect workspace not found at ${aspectWorkspacePath}`
     );
   }
 
-  return [
-    `--override_repository=bazel_kotlin_lsp="${aspectWorkspacePath}"`,
-    "--aspects=@bazel_kotlin_lsp//:kotlin_lsp_info.bzl%kotlin_lsp_aspect",
-    "--output_groups=+lsp_infos",
-  ];
+  if (quotePath) {
+    return [
+      `--override_repository=bazel_kotlin_lsp=\"${aspectWorkspacePath}\"`,
+      "--aspects=@bazel_kotlin_lsp//:kotlin_lsp_info.bzl%kotlin_lsp_aspect",
+      "--output_groups=+lsp_infos",
+    ];
+  } else {
+    return [
+      `--override_repository=bazel_kotlin_lsp=${aspectWorkspacePath}`,
+      "--aspects=@bazel_kotlin_lsp//:kotlin_lsp_info.bzl%kotlin_lsp_aspect",
+      "--output_groups=+lsp_infos",
+    ];
+  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,14 @@ export interface BazelKLSConfig {
     debugAttachPort: number;
     aspectSourcesPath: string;
     buildFlags: string[];
+    debugAdapter: BazelKotlinDebugAdapterConfig
+}
+
+export interface BazelKotlinDebugAdapterConfig {
+    enabled: boolean;
+    installPath: string;
+    path: string | undefined;
+    version: string
 }
 
 export class ConfigurationManager {
@@ -20,11 +28,13 @@ export class ConfigurationManager {
     private languageServerInstallPath: string;
     private config: vscode.WorkspaceConfiguration;
     private aspectSourcesPath: string;
+    private debugAdapterInstallPath: string;
 
     constructor(storagePath: string) {
         this.languageServerInstallPath = path.join(storagePath, 'languageServer');
         this.aspectSourcesPath = path.join(storagePath, 'aspectSources');
         this.config = vscode.workspace.getConfiguration(ConfigurationManager.SECTION);
+        this.debugAdapterInstallPath = path.join(storagePath, 'debugAdapter');
     }
 
     getConfig(): BazelKLSConfig {
@@ -40,6 +50,12 @@ export class ConfigurationManager {
                 debugAttachPort: this.config.get('debugAttach.port', 5009),
                 aspectSourcesPath: this.aspectSourcesPath,
                 buildFlags: this.config.get("buildFlags", []),
+                debugAdapter: {
+                    enabled: this.config.get('debugAdapter.enabled', false),
+                    installPath: this.debugAdapterInstallPath,
+                    path: this.config.get('debugAdapter.path', undefined),
+                    version: this.config.get('debugAdapter.version', 'v1.3.15-bazel'),
+                }
         };
     }
 

--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -99,7 +99,7 @@ export class KotlinBazelDebugAdapterFactory
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Window,
-        title: "Downloading Kotlin Language Server",
+        title: "Downloading Kotlin Debug Adapter",
         cancellable: false,
       },
       async (progress) => {

--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -1,0 +1,121 @@
+import * as vscode from "vscode";
+import { getBazelAspectArgs } from "./bazelUtils";
+import * as path from "path";
+import { BazelKotlinDebugAdapterConfig } from "./config";
+import { downloadDebugAdapter } from "./githubUtils";
+
+export class KotlinBazelDebugConfigurationProvider
+  implements vscode.DebugConfigurationProvider
+{
+  private readonly aspectSourcesPath: string;
+  constructor(aspectSourcesPath: string) {
+    this.aspectSourcesPath = aspectSourcesPath;
+  }
+
+  resolveDebugConfiguration(
+    folder: vscode.WorkspaceFolder | undefined,
+    config: vscode.DebugConfiguration,
+    token?: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
+    // Make sure the config exists and is for our debug type
+    if (!config.type || config.type !== "kotlin") {
+      return config;
+    }
+
+    // Inject aspect args so that required outputs are generated when LSP builds stuff on its end
+    if (!config.buildFlags) {
+      const aspectArgs = getBazelAspectArgs(this.aspectSourcesPath);
+      config.buildFlags = aspectArgs;
+    }
+
+    // You can also validate other required properties
+    if (!config.bazelTarget) {
+      return vscode.window
+        .showErrorMessage("Bazel target is required")
+        .then((_) => undefined);
+    }
+
+    if (!config.mainClass) {
+      return vscode.window
+        .showErrorMessage("Main class is required")
+        .then((_) => undefined);
+    }
+
+    // Set default workspaceRoot if not provided
+    if (!config.workspaceRoot) {
+      config.workspaceRoot = folder?.uri.fsPath || "${workspaceFolder}";
+    }
+
+    return config;
+  }
+}
+
+export class KotlinBazelDebugAdapterFactory
+  implements vscode.DebugAdapterDescriptorFactory
+{
+  constructor(
+    private readonly logger: vscode.OutputChannel,
+    private readonly config: BazelKotlinDebugAdapterConfig
+  ) {}
+
+  async createDebugAdapterDescriptor(
+    session: vscode.DebugSession
+  ): Promise<vscode.ProviderResult<vscode.DebugAdapterDescriptor>> {
+    this.logger.appendLine(
+      `Creating debug adapter for session: ${session.type}`
+    );
+
+    // Path to your debug adapter binary
+    const debugAdapterPath = await this.maybeDownloadDebugAdapter();
+    this.logger.appendLine(`Using debug adapter binary: ${debugAdapterPath}`);
+    const debugAdapterArgs: string[] = [];
+
+    const env: { [key: string]: string } = {};
+
+    // Copy only string values from process.env
+    Object.keys(process.env).forEach((key) => {
+      if (process.env[key] !== undefined) {
+        env[key] = process.env[key] as string;
+      }
+    });
+    env.JAVA_TOOL_OPTIONS = `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5011`;
+
+    // Return a descriptor that tells VS Code to launch your binary
+    return new vscode.DebugAdapterExecutable(
+      debugAdapterPath!,
+      debugAdapterArgs,
+      { env: env }
+    );
+  }
+
+  private async maybeDownloadDebugAdapter(): Promise<string | undefined> {
+    if (this.config.path) {
+      this.logger.appendLine(
+        `Using debug adapter from local path: ${this.config.path}`
+      );
+      return this.config.path;
+    }
+
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Window,
+        title: "Downloading Kotlin Language Server",
+        cancellable: false,
+      },
+      async (progress) => {
+        await downloadDebugAdapter(
+          "smocherla-brex",
+          this.config.version,
+          this.config.installPath,
+          progress
+        );
+        return path.join(
+          this.config.installPath,
+          "bin",
+          "kotlin-debug-adapter"
+        );
+      }
+    );
+    return undefined;
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { KotlinLanguageClient, configureLanguage } from "./languageClient";
 import { KotestTestController } from "./kotest";
 import { getBazelAspectArgs } from "./bazelUtils";
 import { ASPECT_RELEASE_VERSION } from "./constants";
+import { KotlinBazelDebugConfigurationProvider, KotlinBazelDebugAdapterFactory } from "./debugAdapter";
 
 let kotlinClient: KotlinLanguageClient;
 let kotestController: KotestTestController;
@@ -296,6 +297,21 @@ export async function activate(context: vscode.ExtensionContext) {
   });
 
   context.subscriptions.push(kotestDocumentLister);
+
+  if (config.debugAdapter.enabled) {
+    const outputChannel = vscode.window.createOutputChannel('Kotlin Bazel Debug');
+    const factory = new KotlinBazelDebugAdapterFactory(outputChannel, config.debugAdapter);
+    
+    context.subscriptions.push(
+      vscode.debug.registerDebugAdapterDescriptorFactory('kotlin', factory)
+    );
+    const configProvider = new KotlinBazelDebugConfigurationProvider(config.aspectSourcesPath);
+    context.subscriptions.push(
+      vscode.debug.registerDebugConfigurationProvider('kotlin', configProvider)
+    );
+    context.subscriptions.push(outputChannel);
+    outputChannel.appendLine('Kotlin Bazel Debug extension activated');
+  }
 }
 
 // This method is called when your extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -301,7 +301,7 @@ export async function activate(context: vscode.ExtensionContext) {
   if (config.debugAdapter.enabled) {
     const outputChannel = vscode.window.createOutputChannel('Kotlin Bazel Debug');
     const factory = new KotlinBazelDebugAdapterFactory(outputChannel, config.debugAdapter);
-    
+  
     context.subscriptions.push(
       vscode.debug.registerDebugAdapterDescriptorFactory('kotlin', factory)
     );
@@ -309,6 +309,7 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
       vscode.debug.registerDebugConfigurationProvider('kotlin', configProvider)
     );
+
     context.subscriptions.push(outputChannel);
     outputChannel.appendLine('Kotlin Bazel Debug extension activated');
   }


### PR DESCRIPTION
Towards #9 

With this change, we have initial debugging support
![image (3)](https://github.com/user-attachments/assets/b724a1f6-a9ad-47da-bd9a-8df40b19dc94)


I can view stackframes and locals but the breakpoints are not quite reflected yet in VSCode, that will require a few more fixes in the adapter