### PR TITLE
Support lazy compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
         },
         "bazelKLS.languageServerVersion": {
           "type": "string",
-          "default": "v1.4.0-bazel"
+          "default": "v1.5.0-bazel"
         },
         "bazelKLS.jvmOpts": {
           "type": "array",
@@ -183,6 +183,11 @@
           "type": "boolean",
           "description": "[DEBUG] If enabled (together with debugAttach.enabled), the language server will not immediately launch but instead listen on the specified attach port and wait for a debugger. This is ONLY useful if you need to debug the language server ITSELF.",
           "default": false
+        },
+        "bazelKLS.lazyCompilation": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enables lazy compilation, meaning source files will either be compiled only on-demand (indirectly referenced through other symbols) or when opened explicitly. This is helpful to improve performance in a large repository."
         },
         "bazelKLS.watchFiles": {
           "type": "array",
@@ -261,7 +266,7 @@
         },
         "bazelKLS.debugAdapter.version": {
           "type": "string",
-          "default": "v1.4.0-bazel",
+          "default": "v1.5.0-bazel",
           "description": "The debug adapter version from Github releases"
         },
         "bazelKLS.debugAdapter.path": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,8 @@ export interface BazelKLSConfig {
     debugAttachPort: number;
     aspectSourcesPath: string;
     buildFlags: string[];
-    debugAdapter: BazelKotlinDebugAdapterConfig
+    debugAdapter: BazelKotlinDebugAdapterConfig,
+    lazyCompilation: boolean
 }
 
 export interface BazelKotlinDebugAdapterConfig {
@@ -43,7 +44,7 @@ export class ConfigurationManager {
                 jvmTarget: this.config.get('jvmTarget', '11'),
                 jvmOpts: this.config.get('jvmOpts', []),
                 languageServerInstallPath: this.languageServerInstallPath,
-                languageServerVersion: this.config.get('languageServerVersion', 'v1.4.0-bazel'),
+                languageServerVersion: this.config.get('languageServerVersion', 'v1.5.0-bazel'),
                 javaHome: this.config.get('javaHome', ''),
                 languageServerLocalPath: this.config.get('path', null),
                 debugAttachEnabled: this.config.get('debugAttach.enabled', false),
@@ -54,8 +55,9 @@ export class ConfigurationManager {
                     enabled: this.config.get('debugAdapter.enabled', false),
                     installPath: this.debugAdapterInstallPath,
                     path: this.config.get('debugAdapter.path', undefined),
-                    version: this.config.get('debugAdapter.version', 'v1.4.0-bazel'),
-                }
+                    version: this.config.get('debugAdapter.version', 'v1.5.0-bazel'),
+                },
+                lazyCompilation: this.config.get('lazyCompilation', false),
         };
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,4 +14,6 @@ export const KLS_RELEASE_ARCHIVE_SHA256: Record<string, string> = {
     "e2302bb80902aa47203325268037c0f8793630e80261dca4d00272e61c9cde0f",
   "v1.3.18-bazel":
     "cf8ea6d7f11415957d0bd538d34b7dd199697a7596e6a356b57ec2446331e574",
+  "v1.5.0-bazel":
+     "2e915df0a75d24ddae168a860c507729246c76b99bebab9ad2f40329963bb5fd"
 };

--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -88,7 +88,7 @@ export class KotlinBazelDebugAdapterFactory
     });
 
 
-    const additionalEnvVars = session.configuration.envVars as { [key: string]: string } 
+    const additionalEnvVars = session.configuration.envVars as { [key: string]: string }; 
     const actualEnv = {...env, ...additionalEnvVars};
 
     return new vscode.DebugAdapterExecutable(

--- a/src/githubUtils.ts
+++ b/src/githubUtils.ts
@@ -100,10 +100,10 @@ async function extractZip(zipBuffer: Buffer, destPath: string): Promise<void> {
             const readStream = await new Promise<NodeJS.ReadableStream>(
               (resolve, reject) => {
                 zipfile.openReadStream(entry, (err, stream) => {
-                  if (err) reject(err);
+                  if (err) {reject(err);}
                   else if (!stream)
-                    reject(new Error("No read stream available"));
-                  else resolve(stream);
+                    {reject(new Error("No read stream available"));}
+                  else {resolve(stream);}
                 });
               }
             );

--- a/src/kotest.ts
+++ b/src/kotest.ts
@@ -105,10 +105,10 @@ export class KotestTestController {
             run.enqueued(test);
             try {
                 const uri = test.uri;
-                if (!uri) continue;
+                if (!uri) {continue;}
 
                 const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
-                if (!workspaceFolder) continue;
+                if (!workspaceFolder) {continue;}
 
                 const relativePath = path.relative(workspaceFolder.uri.fsPath, uri.fsPath);
                 const testFilter = `--test_filter="${test.label}"`;
@@ -117,8 +117,8 @@ export class KotestTestController {
                 const queryCommand = `bazel query 'kind(kt_jvm_test, //${path.dirname(relativePath)}:all)'`;
                 const targets = await new Promise<string>((resolve, reject) => {
                     cp.exec(queryCommand, { cwd: workspaceFolder.uri.fsPath }, (error, stdout) => {
-                        if (error) reject(error);
-                        else resolve(stdout.trim());
+                        if (error) {reject(error);}
+                        else {resolve(stdout.trim());}
                     });
                 });
 

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -31,12 +31,13 @@ suite('ConfigurationManager Integration Test Suite', () => {
         assert.strictEqual(config.enabled, true);
         assert.strictEqual(config.jvmTarget, '11');
         assert.deepStrictEqual(config.jvmOpts, []);
-        assert.strictEqual(config.languageServerVersion, 'v1.4.0-bazel');
+        assert.strictEqual(config.languageServerVersion, 'v1.5.0-bazel');
         assert.strictEqual(config.javaHome, '');
         assert.strictEqual(config.languageServerLocalPath, '');
         assert.strictEqual(config.debugAttachEnabled, false);
         assert.strictEqual(config.debugAttachPort, 5009);
-        assert.strictEqual(config.buildFlags.length, 0)
+        assert.strictEqual(config.buildFlags.length, 0);
+        assert.strictEqual(config.lazyCompilation, false);
         
         // Verify storage paths
         assert.strictEqual(
@@ -56,6 +57,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
                 jvmTarget: '17',
                 jvmOpts: ['-Xmx2g'],
                 buildFlags: ["--config=remote"],
+                lazyCompilation: true,
             } as any
         );
         
@@ -68,6 +70,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
         assert.strictEqual(updatedConfig.jvmTarget, '17');
         assert.deepStrictEqual(updatedConfig.jvmOpts, ['-Xmx2g']);
         assert.strictEqual(updatedConfig.buildFlags.length, 1);
-        assert.deepEqual(updatedConfig.buildFlags, ["--config=remote"])
+        assert.deepEqual(updatedConfig.buildFlags, ["--config=remote"]);
+        assert.strictEqual(updatedConfig.lazyCompilation, true);
     });
 });


### PR DESCRIPTION
Towards #32 

For larger repos, the initial source path sync can be extrenely slow and resource intensive due to the number of source files that need to be compiled and indexed.

This adds support for "lazily" compiling files and getting their ModuleDescriptor, this was implemented in the LSP here https://github.com/smocherla-brex/kotlin-language-server-bazel-support/pull/36

- By default, it only compiles files that are open
- additionally if any files are referenced through other symbols for `Go-to-definition`, we figure out the source files for the descriptor based on the JVM name and compile them on-demand and index them. 
- Syntax highlighting will work since all the symbols are in the classpath already and available as module dependencies for the available file.

This helps with performance a lot as user is not blocked on writing code, however I've not verified a lot of the functionality works 100%. So, I've made this optional with the `bazelKLS.lazyCompilation` config option and the difference will only show up in medium-to-large repos.

Also run eslint fix on the code