### PR TITLE
Increase stdout/stderr buffer size

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -186,7 +186,8 @@ export async function activate(context: vscode.ExtensionContext) {
         )} ${bazelAspectArgs.join(" ")}`;
         outputChannel.appendLine(`Building targets: ${buildCmd}`);
 
-        const bazelProcess = cp.exec(buildCmd, { cwd: currentDir });
+        // Use a buffer of 10 MB since a ton of log output may crash the process
+        const bazelProcess = cp.exec(buildCmd, { cwd: currentDir, maxBuffer: 1024 * 1024 * 10 });
 
         const disposable = {
           dispose: () => {


### PR DESCRIPTION
Attempts to solve #30 

If the output being sent by the build process exceeds maxBuffer https://nodejs.org/api/child_process.html#maxbuffer-and-unicode then the process is terminated, increase the buffer size for now to account for that. Default is 1MB