### PR TITLE
Propagate lazy initialization config on startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bazel-kotlin-vscode-extension",
-  "version": "0.2.0-rc.2",
+  "version": "0.2.0-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bazel-kotlin-vscode-extension",
-      "version": "0.2.0-rc.2",
+      "version": "0.2.0-rc.3",
       "dependencies": {
         "@types/yauzl": "^2.10.3",
         "find-process": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bazel-kotlin-vscode-extension",
   "displayName": "bazel-kotlin-vscode-extension",
   "description": "Extension to support Bazel with Kotlin Language Server and Kotlin Debug Adapter",
-  "version": "0.2.0-rc.2",
+  "version": "0.2.0-rc.3",
   "publisher": "SridharMocherla",
   "icon": "resources/kotlin-bazel-logo.png",
   "repository": {
@@ -141,7 +141,7 @@
         },
         "bazelKLS.languageServerVersion": {
           "type": "string",
-          "default": "v1.5.1-bazel"
+          "default": "v1.5.2-bazel"
         },
         "bazelKLS.jvmOpts": {
           "type": "array",
@@ -266,7 +266,7 @@
         },
         "bazelKLS.debugAdapter.version": {
           "type": "string",
-          "default": "v1.5.1-bazel",
+          "default": "v1.5.2-bazel",
           "description": "The debug adapter version from Github releases"
         },
         "bazelKLS.debugAdapter.path": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,5 +16,8 @@ export const KLS_RELEASE_ARCHIVE_SHA256: Record<string, string> = {
     "cf8ea6d7f11415957d0bd538d34b7dd199697a7596e6a356b57ec2446331e574",
   "v1.5.0-bazel":
     "2e915df0a75d24ddae168a860c507729246c76b99bebab9ad2f40329963bb5fd",
-  "v1.5.1-bazel": "10351d04fbcb2f9ef42e55e808a5d10b6d5090e146bf65c698ff47b18f19650d",
+  "v1.5.1-bazel":
+    "10351d04fbcb2f9ef42e55e808a5d10b6d5090e146bf65c698ff47b18f19650d",
+  "v1.5.2-bazel":
+    "25cf3f238c0948832726867477de4b145d017467f4184e2384532ecc8ef8d169",
 };

--- a/src/languageClient.ts
+++ b/src/languageClient.ts
@@ -131,6 +131,7 @@ export class KotlinLanguageClient {
       },
       initializationOptions: {
         storagePath: this.context.storageUri?.fsPath,
+        lazyCompilation: config.lazyCompilation,
       },
       outputChannel: options.outputChannel,
       revealOutputChannelOn: RevealOutputChannelOn.Never,

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -31,7 +31,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
         assert.strictEqual(config.enabled, true);
         assert.strictEqual(config.jvmTarget, '11');
         assert.deepStrictEqual(config.jvmOpts, []);
-        assert.strictEqual(config.languageServerVersion, 'v1.5.1-bazel');
+        assert.strictEqual(config.languageServerVersion, 'v1.5.2-bazel');
         assert.strictEqual(config.javaHome, '');
         assert.strictEqual(config.languageServerLocalPath, '');
         assert.strictEqual(config.debugAttachEnabled, false);


### PR DESCRIPTION
Without it, it always picks up the default on the LSP (disabled), and if you updated the config it would always use that config until the VSCode process was running. Starting over would not respect the vscode config. this fixes it.

We should also pass some of the other config (jvmTarget) like this, but that's a separate change