### PR TITLE
Add stop button for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
         "command": "bazel-kotlin-vscode-extension.clearCaches",
         "title": "Kotlin: Clear Language Server Caches",
         "category": "Kotlin"
+      },
+      {
+        "command": "bazel-kotlin-vscode-extension.stopBuild",
+        "title": "Bazel KLS Sync: Stop Running Build",
+        "icon": "$(stop)"
       }
     ],
     "debuggers": [


### PR DESCRIPTION
Solves #45 

Adds a simple button to stop a running a build. A build can take quite a while and there may be reasons someone wants to stop a build (maybe run some other bazel commands in the terminal) without needing to close vscode itself.