### PR TITLE
Make lazy compilation the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Note that your test runner needs to support `--test_filter` to run single tests 
 
 ### Lazy Compilation
 
-By default, once you sync a Bazel package, the LSP will try to compile all the source files in the workspace that are in the transitive closure of the targets that were built to compute the module descriptors and the PSI represenation of the source files. In a large repo involving thousands of source files, this may lead to very high resource usage and the initial sync could be significantly slow. To better support this usecase, a lazy/on-demand compilation mode is available as opt-in with
+By default, once you sync a Bazel package, the LSP will try to compile all the source files in the workspace that are in the transitive closure of the targets that were built to compute the module descriptors and the PSI represenation of the source files. In a large repo involving thousands of source files, this may lead to very high resource usage and the initial sync could be significantly slow. To better support this usecase, a lazy/on-demand compilation mode is available by default. It can be disabled with the following configuration option:
 ```
-bazelKLS.lazyCompilation: true
+bazelKLS.lazyCompilation: false
 ```
 
-configuration option, which will only compile the files that are open initially. When symbols in other files are referenced through `Go-to-definition`, compilation of those files is triggered so as to support navigation. This may not work 100% though, so it's currently enabled as opt-in. However, this may become the default in the future.
+When lazy compilation is enabled, the LSP will only compile the files that are open initially. When symbols in other files are referenced through `Go-to-definition`, compilation of those files is triggered so as to support navigation. The LSP will still index all the symbols globally after the first Bazel sync, so you still get the benefits of completions and quick fixes even though we don't compile everything. This is because we pre-compute a lot of things in the `bazel build` through an aspect, so it becomes redundant to do so again in the LSP for all files.
 
 ### Debugging
 You can now debug using a customized implementation of [Kotlin Debug Adapter](https://github.com/fwcd/kotlin-debug-adapter) using a launch configuration. This is currently experimental.
@@ -86,11 +86,6 @@ Please check existing [Github issues](https://github.com/smocherla-brex/bazel-ko
 Working on changes scoped to just the extension should be fairly straightforward following the VSCode [guides](https://code.visualstudio.com/api/extension-guides/overview).
 
 If you're trying to integrate changes to the language server into the extension and test it end-to-end, please follow instructions [here](https://github.com/smocherla-brex/kotlin-language-server-bazel-support/blob/main/DEVELOPMENT.md).
-
-## TODO
-
-- [ ] Some more performance improvements to the completions.
-- [ ] Improve performance with large files and especially with growing symbol index.
 
 
 ## Relevant Configuration options

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bazel-kotlin-vscode-extension",
-  "version": "0.3.0.rc-1",
+  "version": "0.3.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bazel-kotlin-vscode-extension",
-      "version": "0.3.0.rc-1",
+      "version": "0.3.0-rc.1",
       "dependencies": {
         "@types/yauzl": "^2.10.3",
         "find-process": "1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bazel-kotlin-vscode-extension",
-  "version": "0.2.0",
+  "version": "0.3.0.rc-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bazel-kotlin-vscode-extension",
-      "version": "0.2.0",
+      "version": "0.3.0.rc-1",
       "dependencies": {
         "@types/yauzl": "^2.10.3",
         "find-process": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bazel-kotlin-vscode-extension",
   "displayName": "bazel-kotlin-vscode-extension",
   "description": "Extension to support Bazel with Kotlin Language Server and Kotlin Debug Adapter",
-  "version": "0.2.0",
+  "version": "0.3.0.rc-1",
   "publisher": "SridharMocherla",
   "icon": "resources/kotlin-bazel-logo.png",
   "repository": {
@@ -15,7 +15,8 @@
   "categories": [
     "Other",
     "Programming Languages",
-    "Debuggers"
+    "Debuggers",
+    "Testing"
   ],
   "activationEvents": [
     "onDebug",
@@ -146,7 +147,7 @@
         },
         "bazelKLS.languageServerVersion": {
           "type": "string",
-          "default": "v1.5.3-bazel"
+          "default": "v1.6.0-bazel"
         },
         "bazelKLS.jvmOpts": {
           "type": "array",
@@ -191,7 +192,7 @@
         },
         "bazelKLS.lazyCompilation": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Enables lazy compilation, meaning source files will either be compiled only on-demand (indirectly referenced through other symbols) or when opened explicitly. This is helpful to improve performance in a large repository."
         },
         "bazelKLS.watchFiles": {
@@ -271,7 +272,7 @@
         },
         "bazelKLS.debugAdapter.version": {
           "type": "string",
-          "default": "v1.5.3-bazel",
+          "default": "v1.6.0-bazel",
           "description": "The debug adapter version from Github releases"
         },
         "bazelKLS.debugAdapter.path": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bazel-kotlin-vscode-extension",
   "displayName": "bazel-kotlin-vscode-extension",
   "description": "Extension to support Bazel with Kotlin Language Server and Kotlin Debug Adapter",
-  "version": "0.3.0.rc-1",
+  "version": "0.3.0-rc.1",
   "publisher": "SridharMocherla",
   "icon": "resources/kotlin-bazel-logo.png",
   "repository": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,7 +44,7 @@ export class ConfigurationManager {
                 jvmTarget: this.config.get('jvmTarget', '11'),
                 jvmOpts: this.config.get('jvmOpts', []),
                 languageServerInstallPath: this.languageServerInstallPath,
-                languageServerVersion: this.config.get('languageServerVersion', 'v1.5.3-bazel'),
+                languageServerVersion: this.config.get('languageServerVersion', 'v1.6.0-bazel'),
                 javaHome: this.config.get('javaHome', ''),
                 languageServerLocalPath: this.config.get('path', null),
                 debugAttachEnabled: this.config.get('debugAttach.enabled', false),
@@ -55,7 +55,7 @@ export class ConfigurationManager {
                     enabled: this.config.get('debugAdapter.enabled', false),
                     installPath: this.debugAdapterInstallPath,
                     path: this.config.get('debugAdapter.path', undefined),
-                    version: this.config.get('debugAdapter.version', 'v1.5.3-bazel'),
+                    version: this.config.get('debugAdapter.version', 'v1.6.0-bazel'),
                 },
                 lazyCompilation: this.config.get('lazyCompilation', false),
         };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,4 +22,6 @@ export const KLS_RELEASE_ARCHIVE_SHA256: Record<string, string> = {
     "25cf3f238c0948832726867477de4b145d017467f4184e2384532ecc8ef8d169",
   "v1.5.3-bazel":
     "2d6f765febecb5a9db1c0b412a3292fdea5f4457779892bb049af7fda617dfae",
+  "v1.6.0-bazel":
+    "7617d38bc08ea2a4c92df5626e1b89ffaabedccc9276fc2e6f6ee0507f8fb730",
 };

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -31,7 +31,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
         assert.strictEqual(config.enabled, true);
         assert.strictEqual(config.jvmTarget, '11');
         assert.deepStrictEqual(config.jvmOpts, []);
-        assert.strictEqual(config.languageServerVersion, 'v1.5.3-bazel');
+        assert.strictEqual(config.languageServerVersion, 'v1.6.0-bazel');
         assert.strictEqual(config.javaHome, '');
         assert.strictEqual(config.languageServerLocalPath, '');
         assert.strictEqual(config.debugAttachEnabled, false);

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -37,7 +37,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
         assert.strictEqual(config.debugAttachEnabled, false);
         assert.strictEqual(config.debugAttachPort, 5009);
         assert.strictEqual(config.buildFlags.length, 0);
-        assert.strictEqual(config.lazyCompilation, false);
+        assert.strictEqual(config.lazyCompilation, true);
         
         // Verify storage paths
         assert.strictEqual(


### PR DESCRIPTION
This includes changes from the LSP:
- to revamp symbol indexing, to compute the global index on classpath sync and do it very fast 
- make lazy compilation the default since we need only one file to get the module descriptor and all dependencies.
- some bug fixes and rc bump

Will need to test it out a bit and validate behavior.