### PR TITLE
Fixes for global symbol indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Additionally it also relies on a fork of [Kotlin Debug Adapter](https://github.c
 - Automatically download the language server and keep it up to date.
 - Partially sync Bazel packages on demand, build and notify the language server with updated bazel classpath.
 - Completions
+- Quick fixes/Auto imports
 - Support for Goto-Definition for most usecases.
 - Hover support to show docstrings in some cases.
 - VSCode test explorer integration for kotest based `DescribeSpec` tests.
 - Experimental Debugging support with launch configuration
-- Support for lazy compilation to improve performance
+- Indexing optimized for bazel through pre-computing source/jar metadata during build.
+- Support for lazy compilation to improve performance.
 
 ## Usage
 
@@ -41,12 +43,12 @@ Note that your test runner needs to support `--test_filter` to run single tests 
 
 ### Lazy Compilation
 
-By default, once you sync a Bazel package, the LSP will try to compile all the source files in the workspace that are in the transitive closure of the targets that were built to compute the module descriptors and the PSI represenation of the source files. In a large repo involving thousands of source files, this may lead to very high resource usage and the initial sync could be significantly slow. To better support this usecase, a lazy/on-demand compilation mode is available by default. It can be disabled with the following configuration option:
+In the original implementation, the LSP would try to compile all the source files in the workspace to compute the module descriptors and the PSI represenation of the source files. In a large repo involving thousands of source files, this may lead to very high resource usage and the initial sync could be significantly slow. With our bazel sync implementation, we pre-compute a lot of things in the `bazel build` through an aspect, so it becomes redundant to do so again in the LSP for all files. So we can opt to just do "lazy" compliation but still get the full symbol index through the classpath from the build. THe a lazy/on-demand compilation mode is available by default. It can be disabled with the following configuration option:
 ```
 bazelKLS.lazyCompilation: false
 ```
 
-When lazy compilation is enabled, the LSP will only compile the files that are open initially. When symbols in other files are referenced through `Go-to-definition`, compilation of those files is triggered so as to support navigation. The LSP will still index all the symbols globally after the first Bazel sync, so you still get the benefits of completions and quick fixes even though we don't compile everything. This is because we pre-compute a lot of things in the `bazel build` through an aspect, so it becomes redundant to do so again in the LSP for all files.
+When lazy compilation is enabled, the LSP will only compile the files that are open initially. When symbols in other files are referenced through `Go-to-definition`, compilation of those files is triggered so as to support navigation. The LSP will still index all the symbols globally after the first Bazel sync, so you still get the benefits of completions and quick fixes even though we don't compile everything. 
 
 ### Debugging
 You can now debug using a customized implementation of [Kotlin Debug Adapter](https://github.com/fwcd/kotlin-debug-adapter) using a launch configuration. This is currently experimental.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Additionally it also relies on a fork of [Kotlin Debug Adapter](https://github.c
 ![Bazel Sync](resources/usage.png)
 - You can follow the output in a `Bazel KLS Sync` output channel.
 - Once the build completes, the classpath in the LSP gets updated and the files are analyzed for syntax highlighting and other features.
+- Note: You can stop the sync at any time by running `Bazel KLS Sync: Stop Running Build` command from the command palette or clicking the stop button in the status bar.
 
 ![Completions](resources/completions.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bazel-kotlin-vscode-extension",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bazel-kotlin-vscode-extension",
-      "version": "0.3.0-rc.1",
+      "version": "0.3.0-rc.2",
       "dependencies": {
         "@types/yauzl": "^2.10.3",
         "find-process": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bazel-kotlin-vscode-extension",
   "displayName": "bazel-kotlin-vscode-extension",
   "description": "Extension to support Bazel with Kotlin Language Server and Kotlin Debug Adapter",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "publisher": "SridharMocherla",
   "icon": "resources/kotlin-bazel-logo.png",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
         },
         "bazelKLS.languageServerVersion": {
           "type": "string",
-          "default": "v1.6.0-bazel"
+          "default": "v1.6.1-bazel"
         },
         "bazelKLS.jvmOpts": {
           "type": "array",
@@ -272,7 +272,7 @@
         },
         "bazelKLS.debugAdapter.version": {
           "type": "string",
-          "default": "v1.6.0-bazel",
+          "default": "v1.6.1-bazel",
           "description": "The debug adapter version from Github releases"
         },
         "bazelKLS.debugAdapter.path": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,7 +44,7 @@ export class ConfigurationManager {
                 jvmTarget: this.config.get('jvmTarget', '11'),
                 jvmOpts: this.config.get('jvmOpts', []),
                 languageServerInstallPath: this.languageServerInstallPath,
-                languageServerVersion: this.config.get('languageServerVersion', 'v1.6.0-bazel'),
+                languageServerVersion: this.config.get('languageServerVersion', 'v1.6.1-bazel'),
                 javaHome: this.config.get('javaHome', ''),
                 languageServerLocalPath: this.config.get('path', null),
                 debugAttachEnabled: this.config.get('debugAttach.enabled', false),
@@ -55,7 +55,7 @@ export class ConfigurationManager {
                     enabled: this.config.get('debugAdapter.enabled', false),
                     installPath: this.debugAdapterInstallPath,
                     path: this.config.get('debugAdapter.path', undefined),
-                    version: this.config.get('debugAdapter.version', 'v1.6.0-bazel'),
+                    version: this.config.get('debugAdapter.version', 'v1.6.1-bazel'),
                 },
                 lazyCompilation: this.config.get('lazyCompilation', false),
         };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,4 +24,6 @@ export const KLS_RELEASE_ARCHIVE_SHA256: Record<string, string> = {
     "2d6f765febecb5a9db1c0b412a3292fdea5f4457779892bb049af7fda617dfae",
   "v1.6.0-bazel":
     "7617d38bc08ea2a4c92df5626e1b89ffaabedccc9276fc2e6f6ee0507f8fb730",
+  "v1.6.1-bazel":
+    "91f4a08d0f76209c3e314d995c80be360bde0e2489e18de2c329cba6a5e58efd",
 };

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -31,7 +31,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
         assert.strictEqual(config.enabled, true);
         assert.strictEqual(config.jvmTarget, '11');
         assert.deepStrictEqual(config.jvmOpts, []);
-        assert.strictEqual(config.languageServerVersion, 'v1.6.0-bazel');
+        assert.strictEqual(config.languageServerVersion, 'v1.6.1-bazel');
         assert.strictEqual(config.javaHome, '');
         assert.strictEqual(config.languageServerLocalPath, '');
         assert.strictEqual(config.debugAttachEnabled, false);


### PR DESCRIPTION
- Update README with some fixes on lazy compilation
- Update LSP version to pull in https://github.com/smocherla-brex/kotlin-language-server-bazel-support/pull/44