### PR TITLE
Bump LSP version to include bzlmod support

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
         },
         "bazelKLS.languageServerVersion": {
           "type": "string",
-          "default": "v1.6.2-bazel"
+          "default": "v1.6.3-bazel"
         },
         "bazelKLS.jvmOpts": {
           "type": "array",
@@ -272,7 +272,7 @@
         },
         "bazelKLS.debugAdapter.version": {
           "type": "string",
-          "default": "v1.6.2-bazel",
+          "default": "v1.6.3-bazel",
           "description": "The debug adapter version from Github releases"
         },
         "bazelKLS.debugAdapter.path": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,7 +44,7 @@ export class ConfigurationManager {
                 jvmTarget: this.config.get('jvmTarget', '11'),
                 jvmOpts: this.config.get('jvmOpts', []),
                 languageServerInstallPath: this.languageServerInstallPath,
-                languageServerVersion: this.config.get('languageServerVersion', 'v1.6.2-bazel'),
+                languageServerVersion: this.config.get('languageServerVersion', 'v1.6.3-bazel'),
                 javaHome: this.config.get('javaHome', ''),
                 languageServerLocalPath: this.config.get('path', null),
                 debugAttachEnabled: this.config.get('debugAttach.enabled', false),
@@ -55,7 +55,7 @@ export class ConfigurationManager {
                     enabled: this.config.get('debugAdapter.enabled', false),
                     installPath: this.debugAdapterInstallPath,
                     path: this.config.get('debugAdapter.path', undefined),
-                    version: this.config.get('debugAdapter.version', 'v1.6.2-bazel'),
+                    version: this.config.get('debugAdapter.version', 'v1.6.3-bazel'),
                 },
                 lazyCompilation: this.config.get('lazyCompilation', false),
         };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,5 +27,7 @@ export const KLS_RELEASE_ARCHIVE_SHA256: Record<string, string> = {
   "v1.6.1-bazel":
     "91f4a08d0f76209c3e314d995c80be360bde0e2489e18de2c329cba6a5e58efd",
   "v1.6.2-bazel":
-    "83806ddb50b19cbd24ba55a82a74da421ff40593c984036cfbfb7a9d37347051"
+    "83806ddb50b19cbd24ba55a82a74da421ff40593c984036cfbfb7a9d37347051",
+  "v1.6.3-bazel":
+    "972023ba65a9ac321232ba60233b9e88c8b5c7cf18a976b0e102993d9aedcdbb",
 };

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -31,7 +31,7 @@ suite('ConfigurationManager Integration Test Suite', () => {
         assert.strictEqual(config.enabled, true);
         assert.strictEqual(config.jvmTarget, '11');
         assert.deepStrictEqual(config.jvmOpts, []);
-        assert.strictEqual(config.languageServerVersion, 'v1.6.2-bazel');
+        assert.strictEqual(config.languageServerVersion, 'v1.6.3-bazel');
         assert.strictEqual(config.javaHome, '');
         assert.strictEqual(config.languageServerLocalPath, '');
         assert.strictEqual(config.debugAttachEnabled, false);


### PR DESCRIPTION
Pull in https://github.com/smocherla-brex/kotlin-language-server-bazel-support/pull/48