### PR TITLE
Support multiple bazel versions for aspect

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,28 @@
-export const ASPECT_RELEASE_VERSION = "v0.0.4";
-export const ASPECT_RELEASE_ARCHIVE_SHA256: Record<string, string> = {
-  "v0.0.4": "135a16dbe18b40764fb0e8ec8f0bd7f0ae3f73c2e71f049341ef7ba352b78d6a",
-};
+export interface AspectReleaseInfo {
+  version: string;
+  bazelVersion: string;
+  sha256: string;
+}
+
+export const ASPECT_RELEASE_VERSION = "v0.4.1-rc.1";
+
+export const ASPECT_RELEASES: AspectReleaseInfo[] = [
+  {
+    bazelVersion: "6",
+    version: "v0.4.1-rc.1",
+    sha256: "c06759b82267d5c9a5ef12fc280f8463550b15b6440ee24b5b3c93ac6a16f171"
+  },
+  {
+    bazelVersion: "7",
+    version: "v0.4.1-rc.1",
+    sha256: "e802c9ce51b26ce0c23bea4b9f3826908938f90e835e99296e1df44e3982e123"
+  },
+  {
+    bazelVersion: "8",
+    version: "v0.4.1-rc.1",
+    sha256: "ba208777915ce10a0d556f54f9afeba8111104f0824cbff7c98a64797633b3ff"
+  }
+]
 
 export const KLS_RELEASE_ARCHIVE_SHA256: Record<string, string> = {
   "v1.3.14-bazel":

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { downloadAspectReleaseArchive } from "./githubUtils";
 import { ConfigurationManager, BazelKLSConfig } from "./config";
 import { KotlinLanguageClient, configureLanguage } from "./languageClient";
 import { KotestTestController } from "./kotest";
-import { getBazelAspectArgs } from "./bazelUtils";
+import { getBazelAspectArgs, getBazelMajorVersion } from "./bazelUtils";
 import { ASPECT_RELEASE_VERSION } from "./constants";
 import {
   KotlinBazelDebugConfigurationProvider,
@@ -182,10 +182,12 @@ export async function activate(context: vscode.ExtensionContext) {
           return;
         }
 
+
         // Then build those targets with the aspect
+        const bazelMajorVersion = await getBazelMajorVersion(currentDir);
         let aspectSourcesPath = config.aspectSourcesPath;
 
-        const bazelAspectArgs = await getBazelAspectArgs(aspectSourcesPath, currentDir);
+        const bazelAspectArgs = await getBazelAspectArgs(aspectSourcesPath, currentDir, bazelMajorVersion);
         const bazelExecutable = "bazel";
         const bazelArgs = [
           "build",


### PR DESCRIPTION
Based on the current major bazel version, we need to use the right release to support Bazel 6, 7 or 8. Update logic to handle that and download all the relevant archives up front.