### PR TITLE
Attach `--tool_tag` to build invocations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bazel-kotlin-vscode-extension",
-  "version": "0.4.1",
+  "version": "0.4.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bazel-kotlin-vscode-extension",
-      "version": "0.4.1",
+      "version": "0.4.2-rc.1",
       "dependencies": {
         "@types/yauzl": "^2.10.3",
         "find-process": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bazel-kotlin-vscode-extension",
   "displayName": "bazel-kotlin-vscode-extension",
   "description": "Extension to support Bazel with Kotlin Language Server and Kotlin Debug Adapter",
-  "version": "0.4.1",
+  "version": "0.4.2-rc.1",
   "publisher": "SridharMocherla",
   "icon": "resources/kotlin-bazel-logo.png",
   "repository": {

--- a/src/bazelUtils.ts
+++ b/src/bazelUtils.ts
@@ -103,7 +103,7 @@ export function getToolTag(): string {
   switch (appName) {
     case "Cursor":
       return "bazelkls:cursor";
-    case "VS Code":
+    case "Visual Studio Code":
       return "bazelkls:vscode";
     default:
       return "bazelkls:unknown";

--- a/src/bazelUtils.ts
+++ b/src/bazelUtils.ts
@@ -106,6 +106,6 @@ export function getToolTag(): string {
     case "VS Code":
       return "bazelkls:vscode";
     default:
-      return "bazelKLS:Unknown";
+      return "bazelkls:unknown";
   }
 }

--- a/src/bazelUtils.ts
+++ b/src/bazelUtils.ts
@@ -68,10 +68,6 @@ export async function getBazelAspectArgs(
   developmentMode: boolean = false
 ): Promise<string[]> {
   let aspectWorkspacePath = path.join(aspectSourcesPath, bazelVersion, "bazel", "aspect");
-  if (developmentMode) {
-    // if using development mode in vscode, use the aspect sources path directly
-    aspectWorkspacePath = aspectSourcesPath;
-  }
   if (!checkDirectoryExists(aspectWorkspacePath)) {
     throw new Error(
       `Bazel Aspect workspace not found at ${aspectWorkspacePath}`
@@ -95,4 +91,21 @@ export async function getBazelAspectArgs(
     `--aspects=${repoName}//:kotlin_lsp_info.bzl%kotlin_lsp_aspect`,
     "--output_groups=+lsp_infos",
   ];
+}
+
+/**
+ * Provides the tool tag for the current editor, useful in attaching to a bazel build invocation
+ * @returns string
+ */
+
+export function getToolTag(): string {
+  const appName = vscode.env.appName;
+  switch (appName) {
+    case "Cursor":
+      return "bazelkls:cursor";
+    case "VS Code":
+      return "bazelkls:vscode";
+    default:
+      return "bazelKLS:Unknown";
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -194,7 +194,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
         const bazelAspectArgs = await getBazelAspectArgs(aspectSourcesPath, currentDir, bazelMajorVersion, developmentMode);
 
-        const appName = vscode.env.appName;
         const bazelExecutable = "bazel";
         const bazelArgs = [
           "build",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import { downloadAspectReleaseArchive } from "./githubUtils";
 import { ConfigurationManager, BazelKLSConfig } from "./config";
 import { KotlinLanguageClient, configureLanguage } from "./languageClient";
 import { KotestTestController } from "./kotest";
-import { getBazelAspectArgs, getBazelMajorVersion } from "./bazelUtils";
+import { getBazelAspectArgs, getBazelMajorVersion, getToolTag } from "./bazelUtils";
 import { ASPECT_RELEASE_VERSION } from "./constants";
 import {
   KotlinBazelDebugConfigurationProvider,
@@ -193,12 +193,15 @@ export async function activate(context: vscode.ExtensionContext) {
         const developmentMode = context.extensionMode === vscode.ExtensionMode.Development;
 
         const bazelAspectArgs = await getBazelAspectArgs(aspectSourcesPath, currentDir, bazelMajorVersion, developmentMode);
+
+        const appName = vscode.env.appName;
         const bazelExecutable = "bazel";
         const bazelArgs = [
           "build",
           ...config.buildFlags,
           ...targets,
           ...bazelAspectArgs,
+          `--tool_tag=${getToolTag()}`,
         ];
 
         outputChannel.appendLine(


### PR DESCRIPTION
This will be useful for downstream systems that consume BEP to understand:
- the usage of this extension
- the editor from which the builds are coming from.