### PR TITLE
Hotfix: Fix repo name in aspect release download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bazel-kotlin",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bazel-kotlin",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "@types/yauzl": "^2.10.3",
         "find-process": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bazel-kotlin",
   "displayName": "Bazel Kotlin",
   "description": "Extension to support Bazel with Kotlin Language Server and Kotlin Debug Adapter",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "publisher": "Brex",
   "icon": "resources/kotlin-bazel-logo.png",
   "repository": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -417,7 +417,7 @@ async function downloadAspectRelease(
     },
     async (progress) => {
       await downloadAspectReleaseArchive(
-        "bazel-kotlin",
+        "bazel-kotlin-vscode-extension",
         ASPECT_RELEASE_VERSION,
         sourcesPath,
         progress


### PR DESCRIPTION
This got replaced accidentally during the rename and it wasn't detected in local testing because we use a local copy of the aspect and it's also cached.