### PR TITLE
chore: Remove outputChannel.show()

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,7 +136,6 @@ export async function activate(context: vscode.ExtensionContext) {
         return;
       }
 
-      outputChannel.show();
       outputChannel.appendLine(`Starting Bazel sync for: ${uri.fsPath}`);
       outputChannel.appendLine(`Using Bazel workspace: ${currentDir}`);
 


### PR DESCRIPTION
Removed output channel show call before appending lines to prevent the autofocus of the output tab in the embedded terminal