### PR TITLE
Fix 'NoneType' value has no field 'path' when the stdlib jar is version/prefix-named

### DIFF
--- a/bazel/aspect/stdlib.bzl
+++ b/bazel/aspect/stdlib.bzl
@@ -3,21 +3,28 @@ load(":providers.bzl", "KotlinLSPStdLibInfo")
 def _stdlib_to_bin_impl(ctx):
     jvm_stdlibs = ctx.toolchains["@io_bazel_rules_kotlin//kotlin/internal:kt_toolchain_type"].jvm_stdlibs
 
-    outputs = []
-    output_compile_jar = None
-    for java_output in jvm_stdlibs.java_outputs:
-        class_jar = java_output.class_jar
-        if class_jar.path.endswith("-stdlib.jar"):
-            output_compile_jar = ctx.actions.declare_file("kotlin-stdlib.jar")
-            ctx.actions.symlink(
-                output = output_compile_jar,
-                target_file = class_jar,
-            )
-            outputs.append(output_compile_jar)
+    stdlib_jars = [
+        o.class_jar
+        for o in jvm_stdlibs.java_outputs
+        if "kotlin-stdlib" in o.class_jar.basename and
+           o.class_jar.basename.endswith(".jar") and
+           not any([v in o.class_jar.basename for v in ("-jdk", "-common", "-sources", "-js")])
+    ]
+
+    if not stdlib_jars:
+        fail("Could not locate the kotlin-stdlib jar among the toolchain's jvm_stdlibs: {}".format(
+            [o.class_jar.basename for o in jvm_stdlibs.java_outputs],
+        ))
+
+    output_compile_jar = ctx.actions.declare_file("kotlin-stdlib.jar")
+    ctx.actions.symlink(
+        output = output_compile_jar,
+        target_file = stdlib_jars[0],
+    )
 
     return [
         DefaultInfo(
-            files = depset(outputs),
+            files = depset([output_compile_jar]),
         ),
         KotlinLSPStdLibInfo(
             compile_jar = output_compile_jar,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bazel-kotlin",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bazel-kotlin",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@types/yauzl": "^2.10.3",
         "find-process": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bazel-kotlin",
   "displayName": "Bazel Kotlin",
   "description": "Extension to support Bazel with Kotlin Language Server and Kotlin Debug Adapter",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "publisher": "Brex",
   "icon": "resources/kotlin-bazel-logo.png",
   "repository": {


### PR DESCRIPTION
bazel/aspect/stdlib.bzl located the Kotlin stdlib compile jar with an exact -stdlib.jar suffix check.
Toolchains that source the stdlib from Maven via rules_jvm_external expose it as e.g. processed_kotlin-stdlib-1.9.23.jar,
which never matched (so compile_jar stayed None and the aspect crashed on the first kt_jvm_* target in kotlin_lsp_info.bzl with 'NoneType' value has no field 'path').

  This broadens the match to a kotlin-stdlib basename substring (guarding out the -jdk/-common/-sources/-js variants, first match wins)
  and fails with a clear message listing the candidate jars when none is found, instead of letting a None
  propagate downstream.

  Replaces the client-side workaround in brexhq/kotlin-bazel.nvim#9; the fix now lives in the aspect where it belongs.

  Verification

  - buildifier --lint=warn stdlib.bzl — clean (the only warning, module-docstring, is pre-existing on main).
  - Ran the real aspect over this repo's own kt_jvm_library exactly as the extension does — builds clean, confirming no regression for toolchains that name the jar kotlin-stdlib.jar:
  bazel build //lsp_info_extractor:lsp-info-extractor-lib \
    --aspects=//:kotlin_lsp_info.bzl%kotlin_lsp_aspect \
    --output_groups=+lsp_infos
  - bazel aquery //:stdlib-jars confirms the matched toolchain jar is symlinked to kotlin-stdlib.jar.
  - Verified the matcher against a basename table: matches kotlin-stdlib.jar, processed_kotlin-stdlib-1.9.23.jar, kotlin-stdlib-1.9.23.jar; excludes the -jdk7/-jdk8/-common/-js/-sources variants and unrelated jars.
